### PR TITLE
support translations and fixes javascript warnings

### DIFF
--- a/resources/views/livewire/add-new-permission-component.blade.php
+++ b/resources/views/livewire/add-new-permission-component.blade.php
@@ -1,46 +1,47 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <i class="fas fa-key"></i>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <i class="fas fa-key"></i>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
+                Add New Permission
+              </h3>
+            </div>
           </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
-              Add New Permission
-            </h3>
-          </div>
-        </div>
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Permission Name
-                  </label>
-                  <input wire:model="permissionName" class="appearance-none block w-full bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="text" placeholder="Provide New Permission Name">
-                  <p class="text-gray-600 text-xs italic dark:text-gray-400">Permission name should be unique</p>
-                  @error('permissionName') <span class="error text-red-400">{{ $message }}</span> @enderror
-                </div>
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="permissionName">
+                  Permission Name
+                </label>
+                <input wire:model="permissionName" class="appearance-none block w-full bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="permissionName" type="text" placeholder="Provide New Permission Name">
+                <p class="text-gray-600 text-xs italic dark:text-gray-400">Permission name should be unique</p>
+                @error('permissionName') <span class="error text-red-400">{{ $message }}</span> @enderror
               </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button wire:click="addPermission" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
-          Add
-        </button>
-        <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium dark:bg-gray-700 dark:text-gray-200 text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Cancel
-        </button>
+        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button wire:click="addPermission" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
+            Add
+          </button>
+          <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium dark:bg-gray-700 dark:text-gray-200 text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/resources/views/livewire/add-new-role-component.blade.php
+++ b/resources/views/livewire/add-new-role-component.blade.php
@@ -1,47 +1,48 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <i class="fas fa-user-tag"></i>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <i class="fas fa-user-tag"></i>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
+                Add New Role
+              </h3>
+            </div>
           </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
-              Add New Role
-            </h3>
-          </div>
-        </div>
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Role Name
-                  </label>
-                  <input wire:model="roleName" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="text" placeholder="Provide New Role Name">
-                  <p class="text-gray-600 text-xs italic dark:text-gray-400">Role name should be unique</p>
-                  @error('roleName') <span class="error text-red-400">{{ $message }}</span> @enderror
-                </div>
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="roleName">
+                  Role Name
+                </label>
+                <input wire:model="roleName" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="roleName" type="text" placeholder="Provide New Role Name">
+                <p class="text-gray-600 text-xs italic dark:text-gray-400">Role name should be unique</p>
+                @error('roleName') <span class="error text-red-400">{{ $message }}</span> @enderror
               </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button wire:click="addRole" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
-          Add
-        </button>
-        <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border dark:bg-gray-700 dark:text-gray-200 border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Cancel
-        </button>
+        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button wire:click="addRole" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
+            Add
+          </button>
+          <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border dark:bg-gray-700 dark:text-gray-200 border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/resources/views/livewire/add-new-user-component.blade.php
+++ b/resources/views/livewire/add-new-user-component.blade.php
@@ -1,87 +1,89 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z"/></svg>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z" />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
+                Add New User
+              </h3>
+            </div>
           </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
-              Add New User
-            </h3>
+          @error('error')
+          <div class="bg-red-100 border my-2 border-red-400 text-red-700 px-4 py-2 rounded relative" role="alert">
+            <span class="block sm:inline">{{ $message }}</span>
+          </div>
+          @enderror
+
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-name">
+                  Name
+                </label>
+                <input wire:model.defer="name" class="appearance-none block w-full bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-name" type="text" placeholder="Provide User's Name">
+                @error('name') <span class="error text-red-400">{{ $message }}</span> @enderror
+              </div>
+            </div>
+          </div>
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-email">
+                  Email
+                </label>
+                <input wire:model.defer="email" class="appearance-none block w-full bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-email" type="email" placeholder="Provide User's Email">
+                @error('email') <span class="error text-red-400">{{ $message }}</span> @enderror
+              </div>
+            </div>
+          </div>
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="password">
+                  Password
+                </label>
+                <input wire:model.defer="password" class="appearance-none block w-full bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="password" type="password" placeholder="Provide User's Password">
+                <p class="text-gray-600 text-xs italic">Should be of minimum 6 characters.</p>
+                @error('password') <span class="error text-red-400">{{ $message }}</span> @enderror
+              </div>
+            </div>
+          </div>
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password2">
+                  Confirm Password
+                </label>
+                <input wire:model.defer="password_confirmation" class="appearance-none block w-full bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password2" type="password" placeholder="Retype password">
+              </div>
+            </div>
           </div>
         </div>
-        @error('error') 
-        <div class="bg-red-100 border my-2 border-red-400 text-red-700 px-4 py-2 rounded relative" role="alert">
-          <span class="block sm:inline">{{ $message }}</span>
+        <div class="bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button wire:click="addUser" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
+            Add User
+          </button>
+          <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-200 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Cancel
+          </button>
         </div>
-        @enderror
-
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Name
-                  </label>
-                  <input wire:model.defer="name" class="appearance-none block w-full bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="text" placeholder="Provide User's Name">
-                  @error('name') <span class="error text-red-400">{{ $message }}</span> @enderror
-                </div>
-              </div>
-        </div>
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Email
-                  </label>
-                  <input wire:model.defer="email" class="appearance-none block w-full bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="email" placeholder="Provide User's Email">
-                  @error('email') <span class="error text-red-400">{{ $message }}</span> @enderror
-                </div>
-              </div>
-        </div>
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Password
-                  </label>
-                  <input wire:model.defer="password" class="appearance-none block w-full bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="password" placeholder="Provide User's Password">
-                  <p class="text-gray-600 text-xs italic">Should be of minimum 6 characters.</p>
-                  @error('password') <span class="error text-red-400">{{ $message }}</span> @enderror
-                </div>
-              </div>
-        </div>
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Confirm Password
-                  </label>
-                  <input wire:model.defer="password_confirmation" class="appearance-none block w-full bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="password" placeholder="Retype password">
-                </div>
-              </div>
-        </div>
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button wire:click="addUser" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
-          Add User
-        </button>
-        <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-200 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Cancel
-        </button>
       </div>
     </div>
   </div>
-</div>
 </div>

--- a/resources/views/livewire/delete-modal-component.blade.php
+++ b/resources/views/livewire/delete-modal-component.blade.php
@@ -1,42 +1,43 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <svg class="h-6 w-6 text-red-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-            </svg>
-          </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-200" id="modal-title">
-              {{$modalHeading}}
-            </h3>
-            <div class="mt-2">
-              <p class="text-sm text-gray-500 dark:text-gray-300">
-                {{$modalMessage}}
-              </p>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg class="h-6 w-6 text-red-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-200" id="modal-title">
+                {{$modalHeading}}
+              </h3>
+              <div class="mt-2">
+                <p class="text-sm text-gray-500 dark:text-gray-300">
+                  {{$modalMessage}}
+                </p>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button wire:click="destroy" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm">
-          Delete
-        </button>
-        <button @click="show=false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border dark:bg-gray-700 dark:text-gray-200 border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Cancel
-        </button>
+        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button wire:click="destroy" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm">
+            Delete
+          </button>
+          <button @click="show=false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border dark:bg-gray-700 dark:text-gray-200 border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/resources/views/livewire/edit-permission-component.blade.php
+++ b/resources/views/livewire/edit-permission-component.blade.php
@@ -1,47 +1,50 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z"/></svg>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z" />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title" wire:ignore>
+                Edit Permission {{isset($permission) ?  __('permissions.' . $permission->name)  : ''}}
+              </h3>
+            </div>
           </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title" wire:ignore>
-              Edit Permission {{isset($permission) ? $permission->name : ''}}
-            </h3>
-          </div>
-        </div>
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide dark:text-gray-300 text-gray-700 text-xs font-bold mb-2" for="grid-password">
-                    Permission Name
-                  </label>
-                  <input wire:model="permission.name" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="text">
-                  <p class="text-gray-600 text-xs italic dark:text-gray-400">Permission name should be unique</p>
-                  @error('permission.name') <span class="error text-red-400">{{ $message }}</span> @enderror
-                </div>
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide dark:text-gray-300 text-gray-700 text-xs font-bold mb-2" for="permissionName">
+                  Permission Name
+                </label>
+                <input wire:model="permission.name" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="permissionName" type="text">
+                <p class="text-gray-600 text-xs italic dark:text-gray-400">Permission name should be unique</p>
+                @error('permission.name') <span class="error text-red-400">{{ $message }}</span> @enderror
               </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button wire:click="save" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 sm:ml-3 sm:w-auto sm:text-sm">
-          Save
-        </button>
-        <button wire:click="closeModal" x-on:click="show = false"  type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-200 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Cancel
-        </button>
+        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button wire:click="save" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 sm:ml-3 sm:w-auto sm:text-sm">
+            Save
+          </button>
+          <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-200 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/resources/views/livewire/edit-role-component.blade.php
+++ b/resources/views/livewire/edit-role-component.blade.php
@@ -1,88 +1,90 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z"/></svg>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z" />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
+                Edit Role {{isset($role) ?  __('roles.' . $role->name)  : ''}}
+              </h3>
+            </div>
           </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
-              Edit Role {{isset($role) ? $role->name : ''}}
-            </h3>
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="roleName">
+                  Role Name
+                </label>
+                <input wire:model="role.name" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="roleName" type="text" placeholder="Provide New Role Name">
+                <p class="text-gray-600 text-xs italic dark:text-gray-400">Role name should be unique</p>
+                @error('role.name') <span class="error text-red-400">{{ $message }}</span> @enderror
+              </div>
+            </div>
+            <div class="flex-grow flex-wrap -mx-3 my-6">
+              <div class="w-full px-3" wire:ignore>
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="permissionSelect">
+                  Attach Permissions
+                </label>
+                <select style="width: 100%" class="select select-bordered w-full select2" id="permissionSelect" multiple="multiple">
+                  @foreach($allPermissions as $permission)
+                  <option id="{{$permission->name}}">{{ __('permissions.' . $permission->name) }}</option>
+                  @endforeach
+                </select>
+              </div>
+            </div>
           </div>
         </div>
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Role Name
-                  </label>
-                  <input wire:model="role.name" class="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="text" placeholder="Provide New Role Name">
-                  <p class="text-gray-600 text-xs italic dark:text-gray-400">Role name should be unique</p>
-                  @error('role.name') <span class="error text-red-400">{{ $message }}</span> @enderror
-                </div>
-              </div>
-              <div class="flex-grow flex-wrap -mx-3 my-6">
-                <div class="w-full px-3" wire:ignore>
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Attach Permissions
-                  </label>
-                  <select style="width: 100%" class="select select-bordered w-full select2" id="permissionSelect" multiple="multiple" >
-                   @foreach($allPermissions as $permission)
-                       <option id="{{$permission->name}}">{{$permission->name}}</option>
-                   @endforeach
-                   </select>
-                </div>
-              </div>
+        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button wire:click="save" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
+            Save
+          </button>
+          <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border dark:bg-gray-700 dark:text-gray-200 border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Cancel
+          </button>
         </div>
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button wire:click="save" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
-          Save
-        </button>
-        <button wire:click="closeModal" x-on:click="show = false"  type="button" class="mt-3 w-full inline-flex justify-center rounded-md border dark:bg-gray-700 dark:text-gray-200 border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Cancel
-        </button>
       </div>
     </div>
   </div>
-</div>
-<script>
+  <script>
+    document.addEventListener('livewire:load', function(event) {
 
-        document.addEventListener('livewire:load', function (event) {
+      @this.on('refreshPermissionSelect', function() {
+        let associatedPermissions = [];
 
-          @this.on('refreshPermissionSelect', function () {
-             let associatedPermissions = [];
-
-             $.each(@this.associatedPermissions, function(key, associatedPermission){
-                    associatedPermissions.push(associatedPermission)
-             });
-
-              $('#permissionSelect').val(associatedPermissions);
-
-              $('#permissionSelect').select2({
-                tags: true,
-                tokenSeparators: [',']
-              });
-
-              $('#permissionSelect').trigger('change');
-
-              $('#permissionSelect').on('change', function (e) {
-                  @this.set('associatedPermissions', $(this).val());
-              });
-          });
-
-
+        $.each(@this.associatedPermissions, function(key, associatedPermission) {
+          associatedPermissions.push(associatedPermission)
         });
-    </script>
+
+        $('#permissionSelect').val(associatedPermissions);
+
+        $('#permissionSelect').select2({
+          tags: true,
+          tokenSeparators: [',']
+        });
+
+        $('#permissionSelect').trigger('change');
+
+        $('#permissionSelect').on('change', function(e) {
+          @this.set('associatedPermissions', $(this).val());
+        });
+      });
+
+
+    });
+  </script>
+</div>

--- a/resources/views/livewire/edit-user-component.blade.php
+++ b/resources/views/livewire/edit-user-component.blade.php
@@ -1,62 +1,65 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z"/></svg>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z" />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-400" id="modal-title">
+                Edit User {{isset($user) ? $user->name : ''}}
+              </h3>
+            </div>
           </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-400" id="modal-title">
-              Edit User {{isset($user) ? $user->name : ''}}
-            </h3>
+          @error('error')
+          <div class="bg-red-100 border my-2 border-red-400 text-red-700 px-4 py-2 rounded relative" role="alert">
+            <span class="block sm:inline">{{ $message }}</span>
+          </div>
+          @enderror
+
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-edit-name">
+                  Name
+                </label>
+                <input wire:model.defer="user.name" class="appearance-none block w-full bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-edit-name" type="text" placeholder="Provide User's Name">
+                @error('user.name') <span class="error text-red-400">{{ $message }}</span> @enderror
+              </div>
+            </div>
+          </div>
+          <div class="mt-2 w-full">
+            <div class="flex flex-wrap -mx-3 my-6">
+              <div class="w-full px-3">
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-edit-email">
+                  Email
+                </label>
+                <input wire:model="user.email" disabled class="appearance-none block w-full bg-gray-200 text-gray-700 border dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-edit-email" type="email" placeholder="Provide User's Email">
+              </div>
+            </div>
           </div>
         </div>
-        @error('error') 
-        <div class="bg-red-100 border my-2 border-red-400 text-red-700 px-4 py-2 rounded relative" role="alert">
-          <span class="block sm:inline">{{ $message }}</span>
+        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button wire:click="save" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 sm:ml-3 sm:w-auto sm:text-sm">
+            Save
+          </button>
+          <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-200 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Cancel
+          </button>
         </div>
-        @enderror
-
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Name
-                  </label>
-                  <input wire:model.defer="user.name" class="appearance-none block w-full bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="text" placeholder="Provide User's Name">
-                  @error('user.name') <span class="error text-red-400">{{ $message }}</span> @enderror
-                </div>
-              </div>
-        </div>
-        <div class="mt-2 w-full">
-              <div class="flex flex-wrap -mx-3 my-6">
-                <div class="w-full px-3">
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
-                    Email
-                  </label>
-                  <input wire:model="user.email" disabled class="appearance-none block w-full bg-gray-200 text-gray-700 border dark:bg-gray-700 dark:text-gray-300 dark:focus:shadow-outline-gray dark:border-gray-600 border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-password" type="email" placeholder="Provide User's Email">
-                </div>
-              </div>
-        </div>
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button wire:click="save" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 sm:ml-3 sm:w-auto sm:text-sm">
-          Save
-        </button>
-        <button wire:click="closeModal" x-on:click="show = false"  type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-200 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Cancel
-        </button>
       </div>
     </div>
   </div>

--- a/resources/views/livewire/manage-user-roles-component.blade.php
+++ b/resources/views/livewire/manage-user-roles-component.blade.php
@@ -27,27 +27,29 @@
           <div class="mt-2 w-full">
             <div class="flex-grow flex-wrap -mx-3 my-6">
               <div class="w-full px-3" wire:ignore>
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="roleSelect">
-                    Attach Roles
-                  </label>
-                  <select style="width: 100%" class="select select-bordered w-full select2" id="roleSelect" multiple="multiple" >
-                   @foreach($allRoles as $role)
-                       <option id="{{$role->name}}">{{$role->name}}</option>
-                   @endforeach
-                   </select>
-                </div>
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="roleSelect">
+                  Attach Roles
+                </label>
+                <select style="width: 100%" class="select select-bordered w-full select2" id="roleSelect" name="selectedRoles[]" multiple="multiple">
+                  @foreach($allRoles as $role)
+                  <option value="{{$role->name}}">{{$role->name}}</option>
+				  <!-- <option value="{{$role->name}}">{{ __('roles.' . $role->name) }}</option> -->
+                  @endforeach
+                </select>
               </div>
-              <div class="flex-grow flex-wrap -mx-3 my-6">
-                <div class="w-full px-3" wire:ignore>
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="permissionSelect">
-                    Attach Direct Permissions
-                  </label>
-                  <select style="width: 100%" class="select select-bordered w-full select2" id="permissionSelect" multiple="multiple" >
-                   @foreach($allPermissions as $permission)
-                       <option id="{{$permission->name}}">{{$permission->name}}</option>
-                   @endforeach
-                   </select>
-                   <p class="text-gray-600 text-xs italic dark:text-gray-400 mt-2">Use this to directly assign permssions to the user.</p>
+            </div>
+            <div class="flex-grow flex-wrap -mx-3 my-6">
+              <div class="w-full px-3" wire:ignore>
+                <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="permissionSelect">
+                  Attach Direct Permissions
+                </label>
+                <select style="width: 100%" class="select select-bordered w-full select2" id="permissionSelect" name="selectedPermissions[]" multiple="multiple">
+                  @foreach($allPermissions as $permission)
+                  <option value="{{$permission->name}}">{{$permission->name}}</option>
+				  <!-- <option value="{{$permission->name}}">{{ __('permissions.' . $permission->name) }}</option> -->
+                  @endforeach
+                </select>
+                <p class="text-gray-600 text-xs italic dark:text-gray-400 mt-2">Use this to directly assign permssions to the user.</p>
               </div>
             </div>
           </div>

--- a/resources/views/livewire/manage-user-roles-component.blade.php
+++ b/resources/views/livewire/manage-user-roles-component.blade.php
@@ -1,31 +1,33 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z"/></svg>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z" />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
+                Manage Roles / Permissions for {{isset($user) ? $user->name : ''}}
+              </h3>
+            </div>
           </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
-              Manage Roles / Permissions for {{isset($user) ? $user->name : ''}}
-            </h3>
-          </div>
-        </div>
-        <div class="mt-2 w-full">
-              <div class="flex-grow flex-wrap -mx-3 my-6">
-                <div class="w-full px-3" wire:ignore>
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
+          <div class="mt-2 w-full">
+            <div class="flex-grow flex-wrap -mx-3 my-6">
+              <div class="w-full px-3" wire:ignore>
+                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="roleSelect">
                     Attach Roles
                   </label>
                   <select style="width: 100%" class="select select-bordered w-full select2" id="roleSelect" multiple="multiple" >
@@ -37,7 +39,7 @@
               </div>
               <div class="flex-grow flex-wrap -mx-3 my-6">
                 <div class="w-full px-3" wire:ignore>
-                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="grid-password">
+                  <label class="block uppercase tracking-wide text-gray-700 dark:text-gray-300 text-xs font-bold mb-2" for="permissionSelect">
                     Attach Direct Permissions
                   </label>
                   <select style="width: 100%" class="select select-bordered w-full select2" id="permissionSelect" multiple="multiple" >
@@ -46,66 +48,67 @@
                    @endforeach
                    </select>
                    <p class="text-gray-600 text-xs italic dark:text-gray-400 mt-2">Use this to directly assign permssions to the user.</p>
-                </div>
               </div>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button wire:click="saveRoles" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
-          Save
-        </button>
-        <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Cancel
-        </button>
+        <div class="bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button wire:click="saveRoles" type="button" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-purple-600 text-base font-medium text-white hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 sm:ml-3 sm:w-auto sm:text-sm">
+            Save
+          </button>
+          <button wire:click="closeModal" x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   </div>
-</div>
-<script>
+  <script>
+    document.addEventListener('livewire:load', function(event) {
 
-        document.addEventListener('livewire:load', function (event) {
+    
+      @this.on('refreshRoleSelect', function() {
+        let associatedRoles = [];
 
-          @this.on('refreshRoleSelect', function () {
-             let associatedRoles = [];
-
-             $.each(@this.associatedRoles, function(key, associatedRole){
-                    associatedRoles.push(associatedRole)
-                });
-
-              $('#roleSelect').val(associatedRoles);
-
-              $('#roleSelect').select2({
-                tags: true,
-                tokenSeparators: [',']
-              });
-
-              $('#roleSelect').trigger('change');
-
-              $('#roleSelect').on('change', function (e) {
-                  @this.set('associatedRoles', $(this).val());
-              });
-
-
-              let associatedPermissions = [];
-
-             $.each(@this.associatedPermissions, function(key, associatedPermission){
-                    associatedPermissions.push(associatedPermission)
-                });
-
-              $('#permissionSelect').val(associatedPermissions);
-
-              $('#permissionSelect').select2({
-                tags: true,
-                tokenSeparators: [',']
-              });
-
-              $('#permissionSelect').trigger('change');
-
-              $('#permissionSelect').on('change', function (e) {
-                  @this.set('associatedPermissions', $(this).val());
-              });
-          });
-
-
+        $.each(@this.associatedRoles, function(key, associatedRole) {
+          associatedRoles.push(associatedRole)
         });
-    </script>
+
+        $('#roleSelect').val(associatedRoles);
+
+        $('#roleSelect').select2({
+          tags: true,
+          tokenSeparators: [',']
+        });
+
+        $('#roleSelect').trigger('change');
+
+        $('#roleSelect').on('change', function(e) {
+          @this.set('associatedRoles', $(this).val());
+        });
+
+
+        let associatedPermissions = [];
+
+        $.each(@this.associatedPermissions, function(key, associatedPermission) {
+          associatedPermissions.push(associatedPermission)
+        });
+
+        $('#permissionSelect').val(associatedPermissions);
+
+        $('#permissionSelect').select2({
+          tags: true,
+          tokenSeparators: [',']
+        });
+
+        $('#permissionSelect').trigger('change');
+
+        $('#permissionSelect').on('change', function(e) {
+          @this.set('associatedPermissions', $(this).val());
+        });
+      });
+
+
+    });
+  </script>
+</div>

--- a/resources/views/livewire/permissions-crud-component.blade.php
+++ b/resources/views/livewire/permissions-crud-component.blade.php
@@ -1,126 +1,102 @@
 <div>
-  <div class="flex justify-between my-6 mx-3">
-    <div class="text-2xl font-semibold text-gray-700 dark:text-gray-200">
-                Permissions
-    </div>
-    <div>
-    @can('add permission')
-        <button 
-        x-on:click="window.livewire.emitTo('add-new-permission-component','showModal')"
-          class="flex items-center justify-between w-full px-4 py-2 text-sm font-medium leading-5 text-white transition-colors duration-150 bg-purple-600 border border-transparent rounded-lg active:bg-purple-600 hover:bg-purple-700 focus:outline-none focus:shadow-outline-purple">
-                    Add New Permission <span class="ml-2" aria-hidden="true">+</span>
+  <div>
+    <div class="flex justify-between my-6 mx-3">
+      <div class="text-2xl font-semibold text-gray-700 dark:text-gray-200">
+        Permissions
+      </div>
+      <div>
+        @can('admin_permission_create')
+        <button x-on:click="window.livewire.emitTo('add-new-permission-component','showModal')" class="flex items-center justify-between w-full px-4 py-2 text-sm font-medium leading-5 text-white transition-colors duration-150 bg-purple-600 border border-transparent rounded-lg active:bg-purple-600 hover:bg-purple-700 focus:outline-none focus:shadow-outline-purple">
+          Add New Permission <span class="ml-2" aria-hidden="true">+</span>
         </button>
-    @endcan
+        @endcan
 
+      </div>
     </div>
-    </div>
-@can('view permissions')
-<div class="w-full overflow-hidden rounded-lg shadow-xs">
-              <div class="w-full overflow-x-auto">
-                <!-- Permission search box -->
-                <div class="flex flex-1 lg:mr-32 my-2">
-                  <div
-                    class="relative w-full max-w-xl mr-6 focus-within:text-purple-500"
-                  >
-                    <div class="absolute inset-y-0 flex items-center pl-2">
-                      <svg
-                        class="w-4 h-4"
-                        aria-hidden="true"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                      >
-                        <path
-                          fill-rule="evenodd"
-                          d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
-                          clip-rule="evenodd"
-                        ></path>
-                      </svg>
-                    </div>
-                    <input
-                      class="w-full py-2 pl-8 pr-2 text-sm text-gray-700 placeholder-gray-600 bg-gray-100 border-0 rounded-md dark:placeholder-gray-500 dark:focus:shadow-outline-gray dark:focus:placeholder-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:placeholder-gray-500 focus:bg-white focus:border-purple-300 focus:outline-none focus:shadow-outline-purple form-input"
-                      type="text"
-                      placeholder="Search permissions"
-                      aria-label="Search"
-                      wire:model="searchKeyword"
-                    />
+    @can('admin_permission_index')
+    <div class="w-full overflow-hidden rounded-lg shadow-xs">
+      <div class="w-full overflow-x-auto">
+        <!-- Permission search box -->
+        <div class="flex flex-1 lg:mr-32 my-2">
+          <div class="relative w-full max-w-xl mr-6 focus-within:text-purple-500">
+            <div class="absolute inset-y-0 flex items-center pl-2">
+              <svg class="w-4 h-4" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"></path>
+              </svg>
+            </div>
+            <input class="w-full py-2 pl-8 pr-2 text-sm text-gray-700 placeholder-gray-600 bg-gray-100 border-0 rounded-md dark:placeholder-gray-500 dark:focus:shadow-outline-gray dark:focus:placeholder-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:placeholder-gray-500 focus:bg-white focus:border-purple-300 focus:outline-none focus:shadow-outline-purple form-input" type="text" placeholder="Search permissions" aria-label="Search" wire:model="searchKeyword" />
+          </div>
+        </div>
+        <!--Permission Search box ends -->
+        <table class="w-full whitespace-no-wrap">
+          <thead>
+            <tr class="text-xs font-semibold tracking-wide text-left text-gray-500 uppercase border-b dark:border-gray-700 bg-gray-50 dark:text-gray-400 dark:bg-gray-800">
+              <th class="px-4 py-3">Name</th>
+              <th class="px-4 py-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y dark:divide-gray-700 dark:bg-gray-800">
+            @forelse($permissions as $permission)
+            <tr class="text-gray-700 dark:text-gray-400">
+              <td class="px-4 py-3">
+                <div class="flex items-center text-sm">
+                  <div>
+                    <p class="font-semibold">{{ __('permissions.' . $permission->name) }}</p>
                   </div>
                 </div>
-                <!--Permission Search box ends --> 
-                <table class="w-full whitespace-no-wrap">
-                  <thead>
-                    <tr
-                      class="text-xs font-semibold tracking-wide text-left text-gray-500 uppercase border-b dark:border-gray-700 bg-gray-50 dark:text-gray-400 dark:bg-gray-800"
-                    >
-                      <th class="px-4 py-3">Name</th>
-                      <th class="px-4 py-3">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    class="bg-white divide-y dark:divide-gray-700 dark:bg-gray-800"
-                  >
-                    @forelse($permissions as $permission)
-                      <tr class="text-gray-700 dark:text-gray-400">
-                        <td class="px-4 py-3">
-                          <div class="flex items-center text-sm">
-                            <div>
-                              <p class="font-semibold">{{$permission->name}}</p>
-                            </div>
-                          </div>
-                        </td>
-                        <td class="px-4 py-3 text-sm">
-                        @can('view permission')
-                        <i x-on:click="window.livewire.emitTo('show-permission-component','showModal', {{$permission}})" class="fas fa-eye text-indigo-500 px-1 cursor-pointer"></i>
-                        @endcan
-                        @can('edit permission')
-                        <i x-on:click="window.livewire.emitTo('edit-permission-component','showModal', {{$permission}})" class="fa fa-pencil text-indigo-500 px-1 cursor-pointer"></i>
-                        @endcan
-                        @can('delete permission')
-                          <i class="fas fa-trash text-indigo-500 px-1 cursor-pointer"
-                          x-data={} 
-                          x-on:click="window.livewire.emitTo('delete-modal-component','showModal', 'Spatie\\Permission\\Models\\Permission', {{$permission->id}}, 'Delete Permission', 'Are you sure you want to delete this permission {{$permission->name}}')"></i>
-                        @endcan
-                        </td>
-                      </tr>
-                    @empty
-                    <tr class="text-gray-600 dark:text-gray-400">
-                        @if(isset($searchKeyword))
-                        <td colspan="2" class="p-3">
-                        No Permissions found matching your search keyword
-                        </td>
-                        @else
-                        <td colspan="2" class="p-3">
-                        No Permissions in the database
-                        </td>
-                        @endif
-                    </tr>
-                    @endforelse                
-                  </tbody>
-                </table>
-              </div>
-              <div class="mx-2 my-3">
-                  {{$permissions->links()}}
-              </div>
+              </td>
+              <td class="px-4 py-3 text-sm">
+                @can('admin_permission_view')
+                <i x-on:click="window.livewire.emitTo('show-permission-component','showModal', {{$permission}})" class="fas fa-eye text-indigo-500 px-1 cursor-pointer"></i>
+                @endcan
+                @can('admin_permission_edit')
+                <i x-on:click="window.livewire.emitTo('edit-permission-component','showModal', {{$permission}})" class="fa fa-pencil text-indigo-500 px-1 cursor-pointer"></i>
+                @endcan
+                @can('admin_permission_delete')
+                <i class="fas fa-trash text-indigo-500 px-1 cursor-pointer" x-data={} x-on:click="window.livewire.emitTo('delete-modal-component','showModal', 'Spatie\\Permission\\Models\\Permission', {{$permission->id}}, 'admin_permission_delete', 'Are you sure you want to delete this permission {{ __('permissions.' . $permission->name) }}')"></i>
+                @endcan
+              </td>
+            </tr>
+            @empty
+            <tr class="text-gray-600 dark:text-gray-400">
+              @if(isset($searchKeyword))
+              <td colspan="2" class="p-3">
+                No Permissions found matching your search keyword
+              </td>
+              @else
+              <td colspan="2" class="p-3">
+                No Permissions in the database
+              </td>
+              @endif
+            </tr>
+            @endforelse
+          </tbody>
+        </table>
+      </div>
+      <div class="mx-2 my-3">
+        {{$permissions->links()}}
+      </div>
+    </div>
+    @endcan
+  </div>
+  @can('admin_permission_create')
+  <div wire:key="add-permission">
+    <livewire:add-new-permission-component>
+  </div>
+  @endcan
+  @can('admin_permission_edit')
+  <div wire:key="edit-permission">
+    <livewire:edit-permission-component>
+  </div>
+  @endcan
+  @can('admin_permission_delete')
+  <div wire:key="delete-modal">
+    <livewire:delete-modal-component>
+  </div>
+  @endcan
+  @can('admin_permission_view')
+  <div wire:key="show-permission">
+    <livewire:show-permission-component>
+  </div>
+  @endcan
 </div>
-@endcan
-</div>
-@can('add permission')
-<div wire:key="add-permission">
-  <livewire:add-new-permission-component>
-</div>
-@endcan
-@can('edit permission')
-<div wire:key="edit-permission">
-  <livewire:edit-permission-component>
-</div>
-@endcan
-@can('delete permission')
-<div wire:key="delete-modal">
-  <livewire:delete-modal-component>
-</div>
-@endcan
-@can('view permission')
-<div wire:key="show-permission">
-  <livewire:show-permission-component>
-</div>
-@endcan
-

--- a/resources/views/livewire/roles-crud-component.blade.php
+++ b/resources/views/livewire/roles-crud-component.blade.php
@@ -1,126 +1,101 @@
 <div>
-  <div class="flex justify-between my-6 mx-3">
-    <div class="text-2xl font-semibold text-gray-700 dark:text-gray-200">
-                Roles
-    </div>
-    <div>
-      @can('add role')
-        <button 
-        x-on:click="window.livewire.emitTo('add-new-role-component','showModal')"
-          class="flex items-center justify-between w-full px-4 py-2 text-sm font-medium leading-5 text-white transition-colors duration-150 bg-purple-600 border border-transparent rounded-lg active:bg-purple-600 hover:bg-purple-700 focus:outline-none focus:shadow-outline-purple">
-                    Add New Role <span class="ml-2" aria-hidden="true">+</span>
+  <div>
+    <div class="flex justify-between my-6 mx-3">
+      <div class="text-2xl font-semibold text-gray-700 dark:text-gray-200">
+        Roles
+      </div>
+      <div>
+        @can('admin_role_create')
+        <button x-on:click="window.livewire.emitTo('add-new-role-component','showModal')" class="flex items-center justify-between w-full px-4 py-2 text-sm font-medium leading-5 text-white transition-colors duration-150 bg-purple-600 border border-transparent rounded-lg active:bg-purple-600 hover:bg-purple-700 focus:outline-none focus:shadow-outline-purple">
+          Add New Role <span class="ml-2" aria-hidden="true">+</span>
         </button>
-      @endcan
+        @endcan
+      </div>
     </div>
-  </div>
-  @can('view roles')
-<div class="w-full overflow-hidden rounded-lg shadow-xs">
-              <div class="w-full overflow-x-auto">
-              <!-- Role search box -->
-              <div class="flex flex-1 lg:mr-32 my-2">
-                <div
-                  class="relative w-full max-w-xl mr-6 focus-within:text-purple-500"
-                >
-                  <div class="absolute inset-y-0 flex items-center pl-2">
-                    <svg
-                      class="w-4 h-4"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
-                        clip-rule="evenodd"
-                      ></path>
-                    </svg>
+    @can('admin_role_index')
+    <div class="w-full overflow-hidden rounded-lg shadow-xs">
+      <div class="w-full overflow-x-auto">
+        <!-- Role search box -->
+        <div class="flex flex-1 lg:mr-32 my-2">
+          <div class="relative w-full max-w-xl mr-6 focus-within:text-purple-500">
+            <div class="absolute inset-y-0 flex items-center pl-2">
+              <svg class="w-4 h-4" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"></path>
+              </svg>
+            </div>
+            <input class="w-full py-2 pl-8 pr-2 text-sm text-gray-700 placeholder-gray-600 bg-gray-100 border-0 rounded-md dark:placeholder-gray-500 dark:focus:shadow-outline-gray dark:focus:placeholder-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:placeholder-gray-500 focus:bg-white focus:border-purple-300 focus:outline-none focus:shadow-outline-purple form-input" type="text" placeholder="Search roles" aria-label="Search" wire:model="searchKeyword" />
+          </div>
+        </div>
+        <!--Role Search box ends -->
+        <table class="w-full whitespace-no-wrap">
+          <thead>
+            <tr class="text-xs font-semibold tracking-wide text-left text-gray-500 uppercase border-b dark:border-gray-700 bg-gray-50 dark:text-gray-400 dark:bg-gray-800">
+              <th class="px-4 py-3">Name</th>
+              <th class="px-4 py-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y dark:divide-gray-700 dark:bg-gray-800">
+            @forelse($roles as $role)
+            <tr class="text-gray-700 dark:text-gray-400">
+              <td class="px-4 py-3">
+                <div class="flex items-center text-sm">
+                  <div>
+                    <p class="font-semibold">{{ __('roles.' . $role->name) }}</p>
                   </div>
-                  <input
-                    class="w-full py-2 pl-8 pr-2 text-sm text-gray-700 placeholder-gray-600 bg-gray-100 border-0 rounded-md dark:placeholder-gray-500 dark:focus:shadow-outline-gray dark:focus:placeholder-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:placeholder-gray-500 focus:bg-white focus:border-purple-300 focus:outline-none focus:shadow-outline-purple form-input"
-                    type="text"
-                    placeholder="Search roles"
-                    aria-label="Search"
-                    wire:model="searchKeyword"
-                  />
                 </div>
-              </div>
-              <!--Role Search box ends --> 
-                <table class="w-full whitespace-no-wrap">
-                  <thead>
-                    <tr
-                      class="text-xs font-semibold tracking-wide text-left text-gray-500 uppercase border-b dark:border-gray-700 bg-gray-50 dark:text-gray-400 dark:bg-gray-800"
-                    >
-                      <th class="px-4 py-3">Name</th>
-                      <th class="px-4 py-3">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    class="bg-white divide-y dark:divide-gray-700 dark:bg-gray-800"
-                  >
-                    @forelse($roles as $role)
-                      <tr class="text-gray-700 dark:text-gray-400">
-                        <td class="px-4 py-3">
-                          <div class="flex items-center text-sm">
-                            <div>
-                              <p class="font-semibold">{{$role->name}}</p>
-                            </div>
-                          </div>
-                        </td>
-                        <td class="px-4 py-3 text-sm">
-                          @can('view role')
-                          <i x-on:click="window.livewire.emitTo('show-role-component','showModal', {{$role}})" class="fas fa-eye text-indigo-500 px-1 cursor-pointer"></i>
-                          @endcan
-                          @can('edit role')
-                          <i x-on:click="window.livewire.emitTo('edit-role-component','showModal', {{$role}})" class="fa fa-pencil text-indigo-500 px-1 cursor-pointer"></i>
-                          @endcan
-                          @can('delete role')
-                          <i class="fas fa-trash text-indigo-500 px-1 cursor-pointer"
-                          x-data={} 
-                          x-on:click="window.livewire.emitTo('delete-modal-component','showModal', 'Spatie\\Permission\\Models\\Role', {{$role->id}}, 'Delete Role', 'Are you sure you want to delete role {{$role->name}}')"></i>
-                          @endcan
-                        </td>
-                      </tr>
-                      @empty
-                    <tr class="text-gray-600 dark:text-gray-400">
-                        @if(isset($searchKeyword))
-                        <td colspan="2" class="p-3">
-                        No roles found matching your search keyword
-                        </td>
-                        @else
-                        <td colspan="2" class="p-3">
-                        No roles in the database
-                        </td>
-                        @endif
-                    </tr>
-                    @endforelse                  
-                  </tbody>
-                </table>
-              </div>
-              <div class="mx-2 my-3">
-                  {{$roles->links()}}
-              </div>
+              </td>
+              <td class="px-4 py-3 text-sm">
+                @can('admin_role_view')
+                <i x-on:click="window.livewire.emitTo('show-role-component','showModal', {{$role}})" class="fas fa-eye text-indigo-500 px-1 cursor-pointer"></i>
+                @endcan
+                @can('admin_role_edit')
+                <i x-on:click="window.livewire.emitTo('edit-role-component','showModal', {{$role}})" class="fa fa-pencil text-indigo-500 px-1 cursor-pointer"></i>
+                @endcan
+                @can('admin_role_delete')
+                <i class="fas fa-trash text-indigo-500 px-1 cursor-pointer" x-data={} x-on:click="window.livewire.emitTo('delete-modal-component','showModal', 'Spatie\\Permission\\Models\\Role', {{$role->id}}, 'admin_role_delete', 'Are you sure you want to admin_role_delete {{ __('roles.' . $role->name) }}')"></i>
+                @endcan
+              </td>
+            </tr>
+            @empty
+            <tr class="text-gray-600 dark:text-gray-400">
+              @if(isset($searchKeyword))
+              <td colspan="2" class="p-3">
+                No roles found matching your search keyword
+              </td>
+              @else
+              <td colspan="2" class="p-3">
+                No roles in the database
+              </td>
+              @endif
+            </tr>
+            @endforelse
+          </tbody>
+        </table>
+      </div>
+      <div class="mx-2 my-3">
+        {{$roles->links()}}
+      </div>
+    </div>
+    @endcan
+  </div>
+  @can('admin_role_create')
+  <div wire:key="add-role">
+    <livewire:add-new-role-component>
+  </div>
+  @endcan
+  @can('admin_role_delete')
+  <div wire:key="delete-modal">
+    <livewire:delete-modal-component>
+  </div>
+  @endcan
+  @can('admin_role_edit')
+  <div wire:key="edit-role">
+    <livewire:edit-role-component>
+  </div>
+  @endcan
+  @can('admin_role_view')
+  <div wire:key="show-role">
+    <livewire:show-role-component>
+  </div>
+  @endcan
 </div>
-@endcan
-</div>
-@can('add role')
-<div wire:key="add-role">
-  <livewire:add-new-role-component>
-</div>
-@endcan
-@can('delete role')
-<div wire:key="delete-modal">
-  <livewire:delete-modal-component>
-</div>
-@endcan
-@can('edit role')
-<div wire:key="edit-role">
-  <livewire:edit-role-component>
-</div>
-@endcan
-@can('view role')
-<div wire:key="show-role">
-  <livewire:show-role-component>
-</div>
-@endcan
-
-

--- a/resources/views/livewire/show-permission-component.blade.php
+++ b/resources/views/livewire/show-permission-component.blade.php
@@ -1,48 +1,51 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z"/></svg>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z" />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
+                Permission {{isset($permission) ?  __('permissions.' . $permission->name)  : ''}}
+              </h3>
+            </div>
           </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
-              Permission {{isset($permission) ? $permission->name : ''}}
-            </h3>
-          </div>
-        </div>
-        <!--Attached Permissions-->
-        <div>
-          <div class="text-indigo-500 mt-5 mb-2 font-semibold">
-            Roles Attached with this permission
-          </div>
-          @if(!empty($roles))
+          <!--Attached Permissions-->
+          <div>
+            <div class="text-indigo-500 mt-5 mb-2 font-semibold">
+              Roles Attached with this permission
+            </div>
+            @if(!empty($roles))
             @forelse($roles as $role)
             <span class="px-2 py-1 mr-1 my-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full dark:bg-green-700 dark:text-green-100">
-                {{$role->name}}
+              {{ __('roles.' . $role->name) }}
             </span>
             @empty
-                <em>none</em>
+            <em>none</em>
             @endforelse
-           @endif
-        </div>
+            @endif
+          </div>
 
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-200 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Close
-        </button>
+        </div>
+        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 dark:bg-gray-700 dark:text-gray-200 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Close
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/resources/views/livewire/show-role-component.blade.php
+++ b/resources/views/livewire/show-role-component.blade.php
@@ -1,51 +1,54 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z"/></svg>
-          </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
-              Role {{isset($role) ? $role->name : ''}}
-            </h3>
-          </div>
-        </div>
-        <!--Attached Permissions-->
-        <div>
-          <div class="text-indigo-500 mt-5 mb-2 font-semibold">
-            Permissions Attached with this role
-          </div>
-          @if(!empty($permissions))
-           <div class="flex flex-wrap">
-            @forelse($permissions as $permission)
-            <span class="px-2 py-1 mr-1 my-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full dark:bg-green-700 dark:text-green-100">
-                {{$permission->name}}
-            </span>
-            @empty
-                <em>none</em>
-            @endforelse
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z" />
+              </svg>
             </div>
-           @endif
-        </div>
-        
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-300" id="modal-title">
+                Role {{isset($role) ?  __('roles.' . $role->name)  : ''}}
+              </h3>
+            </div>
+          </div>
+          <!--Attached Permissions-->
+          <div>
+            <div class="text-indigo-500 mt-5 mb-2 font-semibold">
+              Permissions Attached with this role
+            </div>
+            @if(!empty($permissions))
+            <div class="flex flex-wrap">
+              @forelse($permissions as $permission)
+              <span class="px-2 py-1 mr-1 my-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full dark:bg-green-700 dark:text-green-100">
+                {{ __('permissions.' . $permission->name) }}
+              </span>
+              @empty
+              <em>none</em>
+              @endforelse
+            </div>
+            @endif
+          </div>
 
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 dark:text-gray-200 text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Close
-        </button>
+
+        </div>
+        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 dark:text-gray-200 text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Close
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/resources/views/livewire/show-user-component.blade.php
+++ b/resources/views/livewire/show-user-component.blade.php
@@ -1,63 +1,66 @@
 <div x-data="{
     show: @entangle('showModal')
  }" x-show="show" x-cloak>
-<div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-  <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-    
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
+  <div class="fixed z-10 inset-0 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
 
-    <!-- This element is to trick the browser into centering the modal contents. -->
-    <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
 
-    <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-      <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-        <div class="sm:flex md:items-center sm:items-start">
-          <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
-            <!-- Heroicon name: outline/exclamation -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z"/></svg>
+      <!-- This element is to trick the browser into centering the modal contents. -->
+      <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+
+      <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div class="bg-white dark:bg-gray-800 dark:text-gray-400 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+          <div class="sm:flex md:items-center sm:items-start">
+            <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-green-100 sm:mx-0 sm:h-10 sm:w-10">
+              <!-- Heroicon name: outline/exclamation -->
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                <path d="M20.822 18.096c-3.439-.794-6.641-1.49-5.09-4.418 4.719-8.912 1.251-13.678-3.732-13.678-5.081 0-8.464 4.949-3.732 13.678 1.597 2.945-1.725 3.641-5.09 4.418-2.979.688-3.178 2.143-3.178 4.663l.005 1.241h10.483l.704-3h1.615l.704 3h10.483l.005-1.241c.001-2.52-.198-3.975-3.177-4.663zm-8.231 1.904h-1.164l-.91-2h2.994l-.92 2z" />
+              </svg>
+            </div>
+            <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+              <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-400" id="modal-title">
+                {{isset($user) ? $user->name : ''}}
+              </h3>
+            </div>
           </div>
-          <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
-            <h3 class="text-lg leading-6 font-medium text-gray-900 dark:text-gray-400" id="modal-title">
-              {{isset($user) ? $user->name : ''}}
-            </h3>
-          </div>
-        </div>
-        <!--Attached Permissions-->
-        <div>
-          <div class="text-indigo-500 mt-5 mb-2 font-semibold">
-            Roles assigned to this user
-          </div>
-          @if(!empty($roles))
+          <!--Attached Permissions-->
+          <div>
+            <div class="text-indigo-500 mt-5 mb-2 font-semibold">
+              Roles assigned to this user
+            </div>
+            @if(!empty($roles))
             @forelse($roles as $role)
             <span class="px-2 py-1 mr-1 my-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full dark:bg-green-700 dark:text-green-100">
-                {{$role->name}}
+              {{ __('roles.' . $role->name) }}
             </span>
             @empty
-                <em>none</em>
+            <em>none</em>
             @endforelse
-           @endif
-        </div>
-        <!--Attached Users -->
-        <div>
-          <div class="text-indigo-500 mt-5 mb-2 font-semibold">
-            Direct permissions assigned to this user
+            @endif
           </div>
-          @if(!empty($permissions))
+          <!--Attached Users -->
+          <div>
+            <div class="text-indigo-500 mt-5 mb-2 font-semibold">
+              Direct permissions assigned to this user
+            </div>
+            @if(!empty($permissions))
             @forelse($permissions as $permission)
             <span class="px-2 py-1 mr-1 my-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full dark:bg-green-700 dark:text-green-100">
-                {{$permission->name}}
+              {{ __('permissions.' . $permission->name) }}
             </span>
             @empty
-                <em>none</em>
+            <em>none</em>
             @endforelse
-           @endif
-        </div>
+            @endif
+          </div>
 
-      </div>
-      <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
-        <button x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 dark:text-gray-200 text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
-          Close
-        </button>
+        </div>
+        <div class="bg-gray-50 dark:bg-gray-800 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+          <button x-on:click="show = false" type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white dark:bg-gray-700 dark:text-gray-200 text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm">
+            Close
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/resources/views/livewire/users-crud-component.blade.php
+++ b/resources/views/livewire/users-crud-component.blade.php
@@ -1,152 +1,124 @@
 <div>
-<div class="flex justify-between my-6 mx-3">
-    <div class="text-2xl font-semibold text-gray-700 dark:text-gray-200">
-                Users
-    </div>
-    <div>
-      @can('add user')
-        <button 
-        x-on:click="window.livewire.emitTo('add-new-user-component','showModal')"
-          class="flex items-center justify-between w-full px-4 py-2 text-sm font-medium leading-5 text-white transition-colors duration-150 bg-purple-600 border border-transparent rounded-lg active:bg-purple-600 hover:bg-purple-700 focus:outline-none focus:shadow-outline-purple">
-                    Add New User <span class="ml-2" aria-hidden="true">+</span>
+  <div>
+    <div class="flex justify-between my-6 mx-3">
+      <div class="text-2xl font-semibold text-gray-700 dark:text-gray-200">
+        Users
+      </div>
+      <div>
+        @can('admin_user_create')
+        <button x-on:click="window.livewire.emitTo('add-new-user-component','showModal')" class="flex items-center justify-between w-full px-4 py-2 text-sm font-medium leading-5 text-white transition-colors duration-150 bg-purple-600 border border-transparent rounded-lg active:bg-purple-600 hover:bg-purple-700 focus:outline-none focus:shadow-outline-purple">
+          Add New User <span class="ml-2" aria-hidden="true">+</span>
         </button>
-      @endcan
+        @endcan
+      </div>
     </div>
-  </div>
-  @can('view users')
-<div class="w-full overflow-hidden rounded-lg shadow-xs">
-              <div class="w-full overflow-x-auto">
-              <!-- User search box -->
-              <div class="flex flex-1 lg:mr-32 my-2">
-                <div
-                  class="relative w-full max-w-xl mr-6 focus-within:text-purple-500"
-                >
-                  <div class="absolute inset-y-0 flex items-center pl-2">
-                    <svg
-                      class="w-4 h-4"
-                      aria-hidden="true"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                    >
-                      <path
-                        fill-rule="evenodd"
-                        d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
-                        clip-rule="evenodd"
-                      ></path>
-                    </svg>
-                  </div>
-                  <input
-                    class="w-full py-2 pl-8 pr-2 text-sm text-gray-700 placeholder-gray-600 bg-gray-100 border-0 rounded-md dark:placeholder-gray-500 dark:focus:shadow-outline-gray dark:focus:placeholder-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:placeholder-gray-500 focus:bg-white focus:border-purple-300 focus:outline-none focus:shadow-outline-purple form-input"
-                    type="text"
-                    placeholder="Search users"
-                    aria-label="Search"
-                    wire:model="searchKeyword"
-                  />
-                </div>
-              </div>
-              <!--User Search box ends --> 
-              
-                <table class="w-full whitespace-no-wrap">
-                  <thead>
-                    <tr
-                      class="text-xs font-semibold tracking-wide text-left text-gray-500 uppercase border-b dark:border-gray-700 bg-gray-50 dark:text-gray-400 dark:bg-gray-800"
-                    >
-                      <th class="px-4 py-3">Name</th>
-                      <th class="px-4 py-3">Email</th>
-                      <th class="px-4 py-3">Roles</th>
-                      <th class="px-4 py-3">Actions</th>
-                    </tr>
-                  </thead>
-                  <tbody
-                    class="bg-white divide-y dark:divide-gray-700 dark:bg-gray-800"
-                  >
-                    @forelse($users as $user)
-                      <tr class="text-gray-700 dark:text-gray-400">
-                        <td class="px-4 py-3">
-                          <div class="flex items-center text-sm">
-                            <div>
-                              <p class="font-semibold">{{$user->name}}</p>
-                            </div>
-                          </div>
-                        </td>
-                        <td class="px-4 py-3 text-sm">
-                          {{$user->email}}
-                        </td>
-                        <td class="px-4 py-3 text-xs">
-                          @foreach($user->roles as $role)
-                          <span
-                            class="px-2 py-1 mx-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full dark:bg-green-700 dark:text-green-100"
-                          >
-                            {{$role->name}}
-                          </span>
-                          @endforeach
-                        </td>
-                        <td class="px-4 py-3 text-sm">
-                          @can('view user')
-                          <i x-on:click="window.livewire.emitTo('show-user-component','showModal', {{$user}})" class="fas fa-eye text-indigo-500 px-1 cursor-pointer"></i>
-                          @endcan
-                          @can('edit user')
-                          <i x-on:click="window.livewire.emitTo('edit-user-component','showModal', {{$user}})" class="fa fa-pencil text-indigo-500 px-1 cursor-pointer"></i>
-                          @endcan
-                          @can('manage user roles')
-                          <i class="fas fa-user-tag text-indigo-500 px-1 cursor-pointer"
-                          x-data={} 
-                          x-on:click="window.livewire.emitTo('manage-user-roles-component','showModal', {{$user}})"></i>
-                          @endcan
-                          @can('delete user')
-                          <i class="fas fa-trash text-indigo-500 px-1 cursor-pointer"
-                          x-data={} 
-                          x-on:click="window.livewire.emitTo('delete-modal-component','showModal', 'App\\Models\\User', {{$user->id}}, 'Delete User', 'Are you sure you want to delete user {{$user->name}}')"></i>
-                          @endcan
-                        </td>
-                      </tr>
-                      @empty
-                      <tr class="text-gray-600 dark:text-gray-400">
-                          @if(isset($searchKeyword))
-                          <td colspan="2" class="p-3">
-                          No users found matching your search keyword
-                          </td>
-                          @else
-                          <td colspan="2" class="p-3">
-                          No users in the database
-                          </td>
-                          @endif
-                      </tr>
-                    @endforelse                  
-                  </tbody>
-                </table>
-              </div>
-              <div class="mx-2 my-3">
-                 {{$users->links()}}
-              </div>
-</div>
-@else
-<p> You don't have permission to view users </p>
-@endcan
-</div>
-@can('view user')
-<div wire:key="show-user">
-  <livewire:show-user-component>
-</div>
-@endcan
-@can('add user')
-<div wire:key="add-user">
-  <livewire:add-new-user-component>
-</div>
-@endcan
-@can('edit user')
-<div wire:key="edit-user">
-  <livewire:edit-user-component>
-</div>
-@endcan
-@can('manage user roles')
-<div wire:key="manage-role">
-  <livewire:manage-user-roles-component>
-</div>
-@endcan
-@can('delete user')
-<div wire:key="delete-modal">
-  <livewire:delete-modal-component>
-</div>
-@endcan
+    @can('admin_user_index')
+    <div class="w-full overflow-hidden rounded-lg shadow-xs">
+      <div class="w-full overflow-x-auto">
+        <!-- User search box -->
+        <div class="flex flex-1 lg:mr-32 my-2">
+          <div class="relative w-full max-w-xl mr-6 focus-within:text-purple-500">
+            <div class="absolute inset-y-0 flex items-center pl-2">
+              <svg class="w-4 h-4" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd"></path>
+              </svg>
+            </div>
+            <input class="w-full py-2 pl-8 pr-2 text-sm text-gray-700 placeholder-gray-600 bg-gray-100 border-0 rounded-md dark:placeholder-gray-500 dark:focus:shadow-outline-gray dark:focus:placeholder-gray-600 dark:bg-gray-700 dark:text-gray-200 focus:placeholder-gray-500 focus:bg-white focus:border-purple-300 focus:outline-none focus:shadow-outline-purple form-input" type="text" placeholder="Search users" aria-label="Search" wire:model="searchKeyword" />
+          </div>
+        </div>
+        <!--User Search box ends -->
 
+        <table class="w-full whitespace-no-wrap">
+          <thead>
+            <tr class="text-xs font-semibold tracking-wide text-left text-gray-500 uppercase border-b dark:border-gray-700 bg-gray-50 dark:text-gray-400 dark:bg-gray-800">
+              <th class="px-4 py-3">Name</th>
+              <th class="px-4 py-3">Email</th>
+              <th class="px-4 py-3">Roles</th>
+              <th class="px-4 py-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y dark:divide-gray-700 dark:bg-gray-800">
+            @forelse($users as $user)
+            <tr class="text-gray-700 dark:text-gray-400">
+              <td class="px-4 py-3">
+                <div class="flex items-center text-sm">
+                  <div>
+                    <p class="font-semibold">{{$user->name}}</p>
+                  </div>
+                </div>
+              </td>
+              <td class="px-4 py-3 text-sm">
+                {{$user->email}}
+              </td>
+              <td class="px-4 py-3 text-xs">
+                @foreach($user->roles as $role)
+                <span class="px-2 py-1 mx-1 font-semibold leading-tight text-green-700 bg-green-100 rounded-full dark:bg-green-700 dark:text-green-100">
+                  {{ trans('roles.' . $role->name) }}
+                </span>
+                @endforeach
+              </td>
+              <td class="px-4 py-3 text-sm">
+                @can('admin_user_view')
+                <i x-on:click="window.livewire.emitTo('show-user-component','showModal', {{$user}})" class="fas fa-eye text-indigo-500 px-1 cursor-pointer"></i>
+                @endcan
+                @can('admin_user_edit')
+                <i x-on:click="window.livewire.emitTo('edit-user-component','showModal', {{$user}})" class="fa fa-pencil text-indigo-500 px-1 cursor-pointer"></i>
+                @endcan
+                @can('admin_user_roles')
+                <i class="fas fa-user-tag text-indigo-500 px-1 cursor-pointer" x-data={} x-on:click="window.livewire.emitTo('manage-user-roles-component','showModal', {{$user}})"></i>
+                @endcan
+                @can('admin_user_delete')
+                <i class="fas fa-trash text-indigo-500 px-1 cursor-pointer" x-data={} x-on:click="window.livewire.emitTo('delete-modal-component','showModal', 'App\\Models\\User', {{$user->id}}, 'Delete User', 'Are you sure you want to delete user {{$user->name}}')"></i>
+                @endcan
+              </td>
+            </tr>
+            @empty
+            <tr class="text-gray-600 dark:text-gray-400">
+              @if(isset($searchKeyword))
+              <td colspan="2" class="p-3">
+                No users found matching your search keyword
+              </td>
+              @else
+              <td colspan="2" class="p-3">
+                No users in the database
+              </td>
+              @endif
+            </tr>
+            @endforelse
+          </tbody>
+        </table>
+      </div>
+      <div class="mx-2 my-3">
+        {{$users->links()}}
+      </div>
+    </div>
+    @else
+    <p> You don't have permission to view users </p>
+    @endcan
+  </div>
+  @can('admin_user_view')
+  <div wire:key="show-user">
+    <livewire:show-user-component>
+  </div>
+  @endcan
+  @can('admin_user_create')
+  <div wire:key="add-user">
+    <livewire:add-new-user-component>
+  </div>
+  @endcan
+  @can('admin_user_edit')
+  <div wire:key="edit-user">
+    <livewire:edit-user-component>
+  </div>
+  @endcan
+  @can('admin_user_roles')
+  <div wire:key="manage-role">
+    <livewire:manage-user-roles-component>
+  </div>
+  @endcan
+  @can('admin_user_delete')
+  <div wire:key="delete-modal">
+    <livewire:delete-modal-component>
+  </div>
+  @endcan
+</div>


### PR DESCRIPTION
hi, not sure if you are looking for feedback.  

This PR:

1.  fixes Javascript warning from Livewire on multiple root tags
2.  fixes Javascript warnings of using duplicate id's, specifically 'grid-password'
3.  supports my use case requires translatable names described below

My use case requires translatable Names for the Roles and Permissions.  When I would be on the User view page, and click manage user roles and permissions the select2 tags would not be auto selected.  I believe it was because in the code the `<option>` tags were using param `id` instead of `value`.  Changing them to `value` and adding the `name` param to an array, as is shown in the select2 docs fixed my use case.  

I left an example commented out in the code as to how I am using it.  I think it was working in your example because HTML and Javascript were comparing the same thing even though `id` isn't a param for `option`.  Once I changed the text, it couldn't compare no more.
